### PR TITLE
Add CLI-focused documentation and codebase overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,17 @@ Here is a typical workflow for using `delt-hit`:
     --counts_path /path/to/selections/SELECTION_NAME/counts.txt
     ```
 
+## 📚 Documentation
+
+For a codebase overview and a detailed CLI reference, see:
+- [Codebase overview](documentation/overview.md)
+- [CLI guide](documentation/cli.md)
+
+The original protocol description lives in `protocols.pdf`.
+
 ## 💻 CLI Reference
+
+For the most up-to-date CLI details and output locations, use the [CLI guide](documentation/cli.md).
 
 ### `init`
 Initializes a project by creating a `config.yaml` from a standardized Excel file.

--- a/documentation/cli.md
+++ b/documentation/cli.md
@@ -1,0 +1,171 @@
+# DELT-Hit CLI guide
+
+The CLI is the main entrypoint for running DELT-Hit workflows. It is exposed via the `delt-hit` console script and uses `jsonargparse` to map subcommands to public methods in the CLI classes.
+
+```
+delt-hit <group> <method> [--args]
+```
+
+The available groups are:
+- `init`
+- `library`
+- `demultiplex`
+- `analyse`
+- `dashboard`
+
+> Tip: run `delt-hit --help` or `delt-hit <group> --help` to see argument details.
+
+## Configuration inputs
+Most commands expect a YAML configuration file. The standard way to create it is:
+
+```
+delt-hit init --excel_path <path/to/library.xlsx>
+```
+
+The resulting `config.yaml` contains:
+- `experiment`: name, save directory, input FASTQ path, CPU cores.
+- `selections`: metadata for each selection plus primer identifiers.
+- `library`: reaction graph edges and building-block definitions.
+- `catalog`: reaction SMARTS and compound definitions.
+- `structure`: parsing structure (selection/building block/constant regions).
+- `whitelists`: codon lists derived from selections, building blocks, and constants.
+
+The configuration layout is derived directly from the Excel template sheets (see `templates/library.xlsx`) and is parsed by `delt_hit.demultiplex.parser`.
+
+## `init`
+Creates a YAML config from an Excel template.
+
+```
+delt-hit init --excel_path <path/to/library.xlsx>
+```
+
+**Outputs**
+- `<save_dir>/<experiment_name>/config.yaml`
+
+## `demultiplex`
+Provides FASTQ demultiplexing and post-processing of Cutadapt outputs.
+
+### `prepare`
+Generates Cutadapt input files and an executable shell script.
+
+```
+delt-hit demultiplex prepare --config_path <path/to/config.yaml>
+```
+
+**Outputs**
+- `<save_dir>/<experiment_name>/demultiplex/cutadapt_input_files/`
+- `demultiplex.sh` shell script that chains Cutadapt steps
+- FASTQ barcode files per region (`S*`, `B*`, etc.)
+
+### `run`
+Runs the demultiplexing pipeline end-to-end by generating the script and executing it.
+
+```
+delt-hit demultiplex run --config_path <path/to/config.yaml>
+```
+
+### `process`
+Consumes Cutadapt output and computes per-selection barcode counts.
+
+```
+delt-hit demultiplex process --config_path <path/to/config.yaml>
+```
+
+**Outputs**
+- `<save_dir>/<experiment_name>/selections/<SELECTION_NAME>/counts.txt`
+  - `code_1`, `code_2`, … columns plus `count`
+
+### `report`
+Builds a text summary of Cutadapt statistics.
+
+```
+delt-hit demultiplex report --config_path <path/to/config.yaml>
+```
+
+**Outputs**
+- `<save_dir>/<experiment_name>/qc/report.txt`
+
+### `qc`
+Generates QC plots from demultiplexed counts.
+
+```
+delt-hit demultiplex qc --config_path <path/to/config.yaml>
+```
+
+**Outputs**
+- `<save_dir>/<experiment_name>/qc/` (plots)
+
+## `library`
+Library and descriptor generation for downstream analysis.
+
+### `enumerate`
+Builds the reaction graph, enumerates building block combinations, and generates SMILES.
+
+```
+delt-hit library enumerate --config_path <path/to/config.yaml>
+```
+
+Useful options:
+- `--overwrite` to re-generate an existing library
+- `--graph_only` to skip enumeration and only write reaction graph visualizations
+- `--building_block_ids` to enumerate a subset of building blocks
+
+**Outputs**
+- `<save_dir>/<experiment_name>/library/library.parquet`
+- Reaction graph PNGs in the same directory
+
+### `properties`
+Computes molecular properties (RDKit/chem-informatics descriptors) and plots their distributions.
+
+```
+delt-hit library properties --config_path <path/to/config.yaml>
+```
+
+**Outputs**
+- `<save_dir>/<experiment_name>/library/properties/properties.parquet`
+- Histogram PNGs per property
+
+### `represent`
+Generates machine-learning representations (fingerprints).
+
+```
+delt-hit library represent --config_path <path/to/config.yaml> --method morgan
+```
+
+Supported methods:
+- `morgan` (stored as a SciPy sparse matrix)
+- `bert` (currently routed through the Morgan generator in the CLI wrapper; see implementation)
+
+**Outputs**
+- `<save_dir>/<experiment_name>/representations/<method>.npz`
+
+## `analyse`
+Statistical analysis over per-selection counts. The analysis config expects an `experiments` list with explicit selection entries and `counts_path` values (see `delt_hit.cli.analyse.api.prepare_data`).
+
+### `enrichment`
+Runs count-based or edgeR-based enrichment analysis.
+
+```
+delt-hit analyse enrichment --config_path <path/to/config.yaml> --name <experiment-name> --method edgeR
+```
+
+**Outputs**
+- `<save_dir>/<experiment_name>/edgeR/` (or `counts/`) with statistics tables and normalized counts.
+
+## `dashboard`
+Launches a Dash web UI for inspecting a single selection’s counts.
+
+```
+delt-hit dashboard --config_path <path/to/config.yaml> --counts_path <path/to/selections/SELECTION_NAME/counts.txt>
+```
+
+The dashboard defaults to port `8050` and displays:
+- experiment metadata
+- selection metadata
+- interactive scatter plots for code combinations
+
+## Where to look in the code
+- CLI wiring: `src/delt_hit/cli/main.py`
+- CLI group implementations: `src/delt_hit/cli/{init,demultiplex,library,analyse,dashboard}`
+- Config parsing: `src/delt_hit/demultiplex/parser.py`
+- Demultiplexing pipeline: `src/delt_hit/demultiplex/preprocess.py` and `src/delt_hit/demultiplex/postprocess.py`

--- a/documentation/overview.md
+++ b/documentation/overview.md
@@ -1,0 +1,27 @@
+# DELT-Hit codebase overview
+
+## Project context
+DELT-Hit is an end-to-end, open-source toolkit for DNA-encoded library (DEL) analysis. The protocol outlines a five-module pipeline that converts raw sequencing reads into analysis-ready chemical information: adaptive demultiplexing, reaction-based structure reconstruction, molecular property/descriptor generation, statistical hit ranking, and integrated QC/visualization. The implementation in this repository mirrors those modules through CLI commands and supporting packages, so each step is callable as part of a reproducible workflow.
+
+## How the pipeline maps to the repository
+
+### Core packages (`src/delt_hit`)
+- **`cli/`**: CLI entrypoints and subcommands (`delt-hit <group> <method>`). These bind to the modules below and are the primary way users interact with the pipeline.
+- **`demultiplex/`**: FASTQ demultiplexing, Cutadapt input generation, and post-processing of counts. The main data products are selection-level count tables in TSV format.
+- **`library/`**: Reaction graph construction, building-block enumeration, and library-level property/descriptor generation. Output is a `library.parquet` dataset with computed properties and fingerprints.
+- **`quality_control/`**: Plotting and summary reports tied to demultiplexing and hit inspection.
+- **`utils.py`**: Shared YAML I/O helpers and small utilities used throughout the CLI.
+
+### Supporting assets
+- **`templates/`**: Excel templates used to initialize configuration via `delt-hit init`.
+- **`protocols.pdf`**: The reference protocol describing the intended scientific workflow and rationale for each module.
+- **`tests/`**: Unit tests that validate core building blocks.
+
+## High-level data flow
+1. **Configuration**: Start from an Excel library template, then run `delt-hit init` to produce a `config.yaml` that captures experiment metadata, library structure, reaction catalog, and barcode/primer definitions.
+2. **Demultiplexing**: Use `delt-hit demultiplex prepare/run` to generate and execute Cutadapt workflows, then `delt-hit demultiplex process` to convert adapter-tagged reads into per-selection count tables.
+3. **Library enumeration**: Use `delt-hit library enumerate` to build the reaction graph and generate SMILES for the complete library. This creates `library.parquet` and reaction graph visualizations.
+4. **Property/descriptor computation**: `delt-hit library properties` and `delt-hit library represent` produce cheminformatics features (properties and fingerprints) for downstream modeling.
+5. **Analysis & QC**: `delt-hit analyse enrichment` runs statistical enrichment (edgeR or count-based) and exports result tables, while `delt-hit demultiplex report/qc` and `delt-hit dashboard` provide textual/visual inspection of the results.
+
+For CLI specifics (arguments, outputs, and example commands), see [documentation/cli.md](cli.md).

--- a/src/delt_hit/cli/README.md
+++ b/src/delt_hit/cli/README.md
@@ -1,44 +1,7 @@
-# API
+# CLI documentation
 
-## Package modules
-- compute: compute smiles, embeddings, diversity
-- demultiplex: demultiplexing fastq files
-- design: design oligos
-- simulate: simulate data
+This directory hosts the CLI entrypoints. For a detailed command reference, outputs, and configuration layout, see:
 
-## Design (This code base might come from Alice)
-delt-cli design init  # create default config file 
-delt-cli design init  --min-intra-codon-dist 3 --avoid-prefix-postfix-overlaps # create default config file
-delt-cli design run <PATH_TO_CONFIG_FILE>  # run design
+- `documentation/cli.md`
 
-## Demultiplex
-delt-cli demultiplex convert <PATH_TO_OLD_STRUCT_FILE> <PATH_TO_NEW_STRUCT_FILE> -> codon lists -> cutadapt_input -> demultiplex.sh
-delt-cli demultiplex init --from-library <PATH_TO_EXCEL_FILE_OF_LIBRARY> -> codon lists -> cutadapt_input -> demultiplex.sh
-
-delt-cli demultiplex create-lists <PATH_TO_EXCEL_FILE_OF_LIBRARY>
-delt-cli demultiplex create-cutadapt-input <PATH_TO_STRUCTUR_FILE> --input input.fastq.gz 
-./cutadapt-input-files/demultiplex.sh 
-delt-cli demultiplex compute-counts <PAHT_TO_FILE_WITH_ADAPTER> 
-delt-cli demultiplex report
-
-# 
-# delt-cli demultiplex run <PATH_TO_DIR>  # run demultiplexing 
-
-
-
-## Compute
-delt-cli compute smiles  # PR#3
-delt-cli compute embeddings
-delt-cli compute features # hydrophilic, pH, ..., etc
-delt-cli compute diversity
-
-## Simulation
-delt-cli simulate init  # create default config file
-delt-cli simulate run <PATH_TO_CONFIG_FILE>  # run simulation
-
-## Quality Control
-delt-cli qc CMD
-
-## DB Management
-delt-cli db register library 
-delt-cli db register fastq
+The main CLI wiring lives in `src/delt_hit/cli/main.py`.


### PR DESCRIPTION
### Motivation
- Improve discoverability of the CLI and make the repository easier to navigate by providing a focused CLI guide and a high-level codebase overview.
- Surface the protocol-backed design by linking the implementation to the `protocols.pdf` reference and centralizing user-facing documentation paths.

### Description
- Add `documentation/cli.md` with a detailed CLI reference that maps `delt-hit <group> <method>` commands to outputs and configuration expectations. 
- Add `documentation/overview.md` with a concise codebase overview mapping the protocol pipeline to the repository structure. 
- Update `README.md` and `src/delt_hit/cli/README.md` to point to the new `documentation/` files and remove the previous `docs/` files, consolidating documentation in `documentation/`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697de2cc4ab083258cd44632c0eee35d)